### PR TITLE
Fix hex package files

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,8 @@ defmodule Jsonnet.MixProject do
     [
       maintainers: ["Michael Simpson"],
       licenses: ["MPL-2.0"],
-      links: %{github: "https://github.com/mjs2600/jsonnet"}
+      links: %{github: "https://github.com/mjs2600/jsonnet"},
+      files: ~w(lib native mix.exs README.md LICENSE.md)
     ]
   end
 


### PR DESCRIPTION
Added the native folder into the hex package.

When the package is fetched from hex it is failing to compile due to the native folder not being present.